### PR TITLE
Add `ready` column to `game_players` table

### DIFF
--- a/misc/integrated_game_data.sql
+++ b/misc/integrated_game_data.sql
@@ -22,11 +22,11 @@ VALUES
 
 /* Add users to game */
 INSERT INTO game_players
-    (created_by, game_id, user_id, position, name_hidden)
+    (created_by, game_id, user_id, position, name_hidden, ready)
 VALUES
-    (1, 1, 2, 1, FALSE),
-    (1, 1, 3, 2, FALSE),
-    (1, 1, 4, 3, FALSE),
-    (1, 1, 5, 4, FALSE),
-    (1, 1, 6, 3, FALSE),
-    (1, 1, 7, 4, FALSE);
+    (1, 1, 2, 1, FALSE, FALSE),
+    (1, 1, 3, 2, FALSE, FALSE),
+    (1, 1, 4, 3, FALSE, FALSE),
+    (1, 1, 5, 4, FALSE, FALSE),
+    (1, 1, 6, 3, FALSE, FALSE),
+    (1, 1, 7, 4, FALSE, FALSE);

--- a/prijateli_tree/app/database.py
+++ b/prijateli_tree/app/database.py
@@ -197,6 +197,7 @@ class Player(Base):
     )
     position = Column(Integer, nullable=False)
     name_hidden = Column(Boolean, nullable=False)
+    ready = Column(Boolean, nullable=False, default=False)
     game = relationship(
         "Game",
         foreign_keys="[game_players.user_id, game_players.game_id]",

--- a/prijateli_tree/migrations/versions/2023-11-02-1917_21c9591d0d5d_.py
+++ b/prijateli_tree/migrations/versions/2023-11-02-1917_21c9591d0d5d_.py
@@ -5,16 +5,17 @@ Revises: 5489fb45e45e
 Create Date: 2023-11-02 19:17:52.387308
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
-revision = '21c9591d0d5d'
-down_revision = '5489fb45e45e'
+
+revision = "21c9591d0d5d"
+down_revision = "5489fb45e45e"
 
 
 def upgrade():
-    op.add_column('game_players', sa.Column('ready', sa.Boolean(), nullable=False))
+    op.add_column("game_players", sa.Column("ready", sa.Boolean(), nullable=False))
 
 
 def downgrade():
-    op.drop_column('game_players', 'ready')
+    op.drop_column("game_players", "ready")

--- a/prijateli_tree/migrations/versions/2023-11-02-1917_21c9591d0d5d_.py
+++ b/prijateli_tree/migrations/versions/2023-11-02-1917_21c9591d0d5d_.py
@@ -1,0 +1,20 @@
+"""empty message
+
+Revision ID: 21c9591d0d5d
+Revises: 5489fb45e45e
+Create Date: 2023-11-02 19:17:52.387308
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '21c9591d0d5d'
+down_revision = '5489fb45e45e'
+
+
+def upgrade():
+    op.add_column('game_players', sa.Column('ready', sa.Boolean(), nullable=False))
+
+
+def downgrade():
+    op.drop_column('game_players', 'ready')


### PR DESCRIPTION
## Describe Your Changes


## Checklist Before Requesting a Review
- [x] The code runs successfully.

```commandline
(prijatelitree-py3.11) michaelp@MacBook-Air-7 PrijateliTree % docker-compose run web alembic --config=./prijateli_tree/migrations/alembic.ini revision --autogenerate
[+] Creating 1/0
 ✔ Container prijatelitree-postgres-1  Running                                                                                                                                                             0.0s 
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.autogenerate.compare] Detected added column 'game_players.ready'
  Generating /usr/src/app/prijateli_tree/migrations/versions/2023-11-02-1917_21c9591d0d5d_.py ...  done
(prijatelitree-py3.11) michaelp@MacBook-Air-7 PrijateliTree % docker-compose run web alembic --config=./prijateli_tree/migrations/alembic.ini upgrade head
[+] Creating 1/0
 ✔ Container prijatelitree-postgres-1  Running                                                                                                                                                             0.0s 
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 5489fb45e45e -> 21c9591d0d5d, empty message
(prijatelitree-py3.11) michaelp@MacBook-Air-7 PrijateliTree % 
```
