### PR TITLE
Add `next_game_id` column to `games`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ The games are a means to provide insights into social learning, the economics of
 
 ## Dev commands
 `make lint`: Runs the `pre-commit` processes and lints the repository.
+`make build`: Builds the Docker images for the application and the database pass through.
+`make start`: Starts the Docker containers based on the images created in the `make build` step.
+`make create_db`: Runs the alembic scripts. This MUST be run before you run the `make start` command, or it will error.
+`make stop`: Stops the running Docker containers.
+`make clean`: Removes all Docker containers.
+`make clean_all`: Removes the database link between the Docker containers and the self-hosted version of PostgreSQL.
+
+## General Debugging Notes
+- If you are failing the `Format-and-Fail` GitHub Action, you must run `make lint` and make any changes it requests.
+- If you have already run the `make` command, you cannot run it again UNLESS you delete all the tables in your hosted database.
+  - This is because the command will attempt to run the Alembic scripts again which will error since all the tables already exist.
 
 ## Data Migrations
 To run a data migration, you need to run the following steps:

--- a/prijateli_tree/app/database.py
+++ b/prijateli_tree/app/database.py
@@ -180,6 +180,11 @@ class Game(Base):
         ForeignKey("game_types.id", name="games_game_type_id_fkey"),
         nullable=False,
     )
+    next_game_id = Column(
+        Integer,
+        ForeignKey("games.id", name="games_next_game_id_fkey"),
+        nullable=True,
+    )
     rounds = Column(Integer, nullable=False)
     practice = Column(Boolean, default=False, nullable=False)
     game_type = relationship(

--- a/prijateli_tree/migrations/versions/2023-11-18-2145_0735fdd31631_.py
+++ b/prijateli_tree/migrations/versions/2023-11-18-2145_0735fdd31631_.py
@@ -5,20 +5,23 @@ Revises: 30991d313ac8
 Create Date: 2023-11-18 21:45:17.443658
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
-
-revision = '0735fdd31631'
-down_revision = '30991d313ac8'
+revision = "0735fdd31631"
+down_revision = "30991d313ac8"
 
 
 def upgrade():
-    op.add_column('games', sa.Column('next_game_id', sa.Integer(), nullable=True))
-    op.create_foreign_key('games_next_game_id_fkey', 'games', 'games', ['next_game_id'], ['id'])
+    op.add_column(
+        "games", sa.Column("next_game_id", sa.Integer(), nullable=True)
+    )
+    op.create_foreign_key(
+        "games_next_game_id_fkey", "games", "games", ["next_game_id"], ["id"]
+    )
 
 
 def downgrade():
-    op.drop_constraint('games_next_game_id_fkey', 'games', type_='foreignkey')
-    op.drop_column('games', 'next_game_id')
+    op.drop_constraint("games_next_game_id_fkey", "games", type_="foreignkey")
+    op.drop_column("games", "next_game_id")

--- a/prijateli_tree/migrations/versions/2023-11-18-2145_0735fdd31631_.py
+++ b/prijateli_tree/migrations/versions/2023-11-18-2145_0735fdd31631_.py
@@ -1,0 +1,24 @@
+"""empty message
+
+Revision ID: 0735fdd31631
+Revises: 30991d313ac8
+Create Date: 2023-11-18 21:45:17.443658
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+
+revision = '0735fdd31631'
+down_revision = '30991d313ac8'
+
+
+def upgrade():
+    op.add_column('games', sa.Column('next_game_id', sa.Integer(), nullable=True))
+    op.create_foreign_key('games_next_game_id_fkey', 'games', 'games', ['next_game_id'], ['id'])
+
+
+def downgrade():
+    op.drop_constraint('games_next_game_id_fkey', 'games', type_='foreignkey')
+    op.drop_column('games', 'next_game_id')


### PR DESCRIPTION
## Describe Your Changes
Adds ability to link games via an extra column on the `games` table. This PR updates documentation as well.

## Non-Obvious Technical Information
Addresses this request: https://github.com/prijatelilab/PrijateliTree/issues/43#issuecomment-1817272294

## Checklist Before Requesting a Review
- [x] The code runs successfully.

```commandline
(prijatelitree-py3.11) michaelp@MacBook-Air-18 PrijateliTree % docker-compose run web alembic --config=./prijateli_tree/migrations/alembic.ini revision --autogenerate
[+] Building 0.0s (0/0)                                                                                                                                                                 docker:desktop-linux
[+] Creating 1/0
 ✔ Container prijatelitree-postgres-1  Running                                                                                                                                                          0.0s 
[+] Building 0.0s (0/0)                                                                                                                                                                 docker:desktop-linux
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.autogenerate.compare] Detected added column 'games.next_game_id'
INFO  [alembic.autogenerate.compare] Detected added foreign key (next_game_id)(id) on table games
  Generating /usr/src/app/prijateli_tree/migrations/versions/2023-11-18-2145_0735fdd31631_.py ...  done
(prijatelitree-py3.11) michaelp@MacBook-Air-18 PrijateliTree % docker-compose run web alembic --config=./prijateli_tree/migrations/alembic.ini upgrade head
[+] Building 0.0s (0/0)                                                                                                                                                                 docker:desktop-linux
[+] Creating 1/0
 ✔ Container prijatelitree-postgres-1  Running                                                                                                                                                          0.0s 
[+] Building 0.0s (0/0)                                                                                                                                                                 docker:desktop-linux
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 30991d313ac8 -> 0735fdd31631, empty message
(prijatelitree-py3.11) michaelp@MacBook-Air-18 PrijateliTree %
```
