### PR TITLE
Move `names_hidden` column

### DIFF
--- a/prijateli_tree/app/database.py
+++ b/prijateli_tree/app/database.py
@@ -153,6 +153,7 @@ class GameType(Base):
     # Will be the representation of the bag, something like RRRRBB, BBBBRR, etc.
     bag = Column(String, nullable=False)
     games = relationship("Game", back_populates="game_type")
+    names_hidden = Column(Boolean, nullable=False, server_default="false")
 
     __table_args__ = (
         CheckConstraint(
@@ -217,7 +218,6 @@ class Player(Base):
         nullable=False,
     )
     position = Column(Integer, nullable=False)
-    name_hidden = Column(Boolean, nullable=False, default=False)
     ready = Column(Boolean, nullable=False, default=False)
     user = relationship("User", foreign_keys="Player.user_id")
     game = relationship(

--- a/prijateli_tree/app/templates/admin_dashboard.html
+++ b/prijateli_tree/app/templates/admin_dashboard.html
@@ -133,6 +133,7 @@
               <th scope="col">ID</th>
               <th scope="col">Network</th>
               <th scope="col">Bag</th>
+              <th scope="col">Hidden Names</th>
               <th scope="col">Number of Games</th>
             </tr>
           </thead>
@@ -147,6 +148,7 @@
                 <th>{{ gt.id }}</th>
                 <td>{{ gt.network|title }}</td>
                 <td>{{ gt.bag }}</td>
+                <td>{{ gt.names_hidden }}</td>
                 <td>{{ gt.games|length }}</td>
               </tr>
             {% endfor %}

--- a/prijateli_tree/migrations/versions/2023-11-20-2030_8d6d2f92cb84_.py
+++ b/prijateli_tree/migrations/versions/2023-11-20-2030_8d6d2f92cb84_.py
@@ -5,18 +5,22 @@ Revises: 0735fdd31631
 Create Date: 2023-11-20 20:30:45.989585
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
-
-revision = '8d6d2f92cb84'
-down_revision = '0735fdd31631'
+revision = "8d6d2f92cb84"
+down_revision = "0735fdd31631"
 
 
 def upgrade():
-    op.drop_column('game_players', 'name_hidden')
-    op.add_column('game_types', sa.Column('names_hidden', sa.Boolean(), server_default='false', nullable=False))
+    op.drop_column("game_players", "name_hidden")
+    op.add_column(
+        "game_types",
+        sa.Column(
+            "names_hidden", sa.Boolean(), server_default="false", nullable=False
+        ),
+    )
     op.execute(
         """
             INSERT INTO game_types
@@ -33,8 +37,13 @@ def upgrade():
 
 
 def downgrade():
-    op.drop_column('game_types', 'names_hidden')
-    op.add_column('game_players', sa.Column('name_hidden', sa.BOOLEAN(), autoincrement=False, nullable=False))
+    op.drop_column("game_types", "names_hidden")
+    op.add_column(
+        "game_players",
+        sa.Column(
+            "name_hidden", sa.BOOLEAN(), autoincrement=False, nullable=False
+        ),
+    )
     op.execute(
         """
             DELETE FROM game_types

--- a/prijateli_tree/migrations/versions/2023-11-20-2030_8d6d2f92cb84_.py
+++ b/prijateli_tree/migrations/versions/2023-11-20-2030_8d6d2f92cb84_.py
@@ -1,0 +1,43 @@
+"""empty message
+
+Revision ID: 8d6d2f92cb84
+Revises: 0735fdd31631
+Create Date: 2023-11-20 20:30:45.989585
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+
+revision = '8d6d2f92cb84'
+down_revision = '0735fdd31631'
+
+
+def upgrade():
+    op.drop_column('game_players', 'name_hidden')
+    op.add_column('game_types', sa.Column('names_hidden', sa.Boolean(), server_default='false', nullable=False))
+    op.execute(
+        """
+            INSERT INTO game_types
+            (network, bag, names_hidden)
+            VALUES
+            ('integrated', 'RRRRBB', TRUE),
+            ('segregated', 'RRRRBB', TRUE),
+            ('self-selected', 'RRRRBB', TRUE),
+            ('integrated', 'BBBBRR', TRUE),
+            ('segregated', 'BBBBRR', TRUE),
+            ('self-selected', 'BBBBRR', TRUE);
+        """
+    )
+
+
+def downgrade():
+    op.drop_column('game_types', 'names_hidden')
+    op.add_column('game_players', sa.Column('name_hidden', sa.BOOLEAN(), autoincrement=False, nullable=False))
+    op.execute(
+        """
+            DELETE FROM game_types
+            WHERE names_hidden = TRUE;
+        """
+    )


### PR DESCRIPTION
## Describe Your Changes
Moved the `names_hidden` to the game level and added column to the Game Types table in the admin dashboard.

## Checklist Before Requesting a Review
- [x] The code runs successfully.

```commandline
(prijatelitree-py3.11) michaelp@MacBook-Air-18 PrijateliTree % make
poetry export --without-hashes --format=requirements.txt > requirements.txt
Configuration file exists at /Users/michaelp/Library/Preferences/pypoetry, reusing this directory.

Consider moving TOML configuration files to /Users/michaelp/Library/Application Support/pypoetry, as support for the legacy directory will be removed in an upcoming release.
docker-compose build
[+] Building 2.1s (13/13) FINISHED                                                                                                                                                      docker:desktop-linux
 => [web internal] load .dockerignore                                                                                                                                                                   0.0s
 => => transferring context: 2B                                                                                                                                                                         0.0s
 => [web internal] load build definition from Dockerfile                                                                                                                                                0.0s
 => => transferring dockerfile: 357B                                                                                                                                                                    0.0s
 => [web internal] load metadata for docker.io/library/python:3.11-slim-buster                                                                                                                          1.0s
 => [web auth] library/python:pull token for registry-1.docker.io                                                                                                                                       0.0s
 => [web 1/7] FROM docker.io/library/python:3.11-slim-buster@sha256:c46b0ae5728c2247b99903098ade3176a58e274d9c7d2efeaaab3e0621a53935                                                                    0.0s
 => [web internal] load build context                                                                                                                                                                   0.2s
 => => transferring context: 6.94MB                                                                                                                                                                     0.2s
 => CACHED [web 2/7] WORKDIR /usr/src/app                                                                                                                                                               0.0s
 => CACHED [web 3/7] RUN apt-get update   && apt-get -y install netcat gcc postgresql libpq-dev python-dev   && apt-get clean                                                                           0.0s
 => CACHED [web 4/7] RUN pip install --upgrade pip                                                                                                                                                      0.0s
 => CACHED [web 5/7] COPY ./requirements.txt .                                                                                                                                                          0.0s
 => CACHED [web 6/7] RUN pip install -r requirements.txt                                                                                                                                                0.0s
 => [web 7/7] COPY . .                                                                                                                                                                                  0.6s
 => [web] exporting to image                                                                                                                                                                            0.3s
 => => exporting layers                                                                                                                                                                                 0.3s
 => => writing image sha256:7c27800928c3035edc4ca885d57a2ea46dffca780457d787e487a6246ffb59de                                                                                                            0.0s
 => => naming to docker.io/library/prijatelitree-web                                                                                                                                                    0.0s
Postgres is up
docker-compose run --rm web alembic --config=./prijateli_tree/migrations/alembic.ini upgrade head
[+] Building 0.0s (0/0)                                                                                                                                                                 docker:desktop-linux
[+] Creating 1/0
 ✔ Container prijatelitree-postgres-1  Running                                                                                                                                                          0.0s 
[+] Building 0.0s (0/0)                                                                                                                                                                 docker:desktop-linux
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade  -> 44f42b35d858, empty message
INFO  [alembic.runtime.migration] Running upgrade 44f42b35d858 -> 47fe187bc716, empty message
INFO  [alembic.runtime.migration] Running upgrade 47fe187bc716 -> e5b498dd07a6, empty message
INFO  [alembic.runtime.migration] Running upgrade e5b498dd07a6 -> 260d503a3c0d, empty message
INFO  [alembic.runtime.migration] Running upgrade 260d503a3c0d -> 8a5c8a351948, empty message
INFO  [alembic.runtime.migration] Running upgrade 8a5c8a351948 -> 5489fb45e45e, empty message
INFO  [alembic.runtime.migration] Running upgrade 5489fb45e45e -> 21c9591d0d5d, empty message
INFO  [alembic.runtime.migration] Running upgrade 21c9591d0d5d -> 30991d313ac8, empty message
INFO  [alembic.runtime.migration] Running upgrade 30991d313ac8 -> 0735fdd31631, empty message
INFO  [alembic.runtime.migration] Running upgrade 0735fdd31631 -> 8d6d2f92cb84, empty message
docker-compose up -d
[+] Building 0.0s (0/0)                                                                                                                                                                 docker:desktop-linux
[+] Running 2/2
 ✔ Container prijatelitree-postgres-1  Running                                                                                                                                                          0.0s 
 ✔ Container prijatelitree-web-1       Started                                                                                                                                                          0.5s 
(prijatelitree-py3.11) michaelp@MacBook-Air-18 PrijateliTree % 
```