### PR TITLE
Fix DB creation issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-default: build create_db start
+default: build start create_db
 
 .PHONY: build
 build:

--- a/Makefile
+++ b/Makefile
@@ -41,3 +41,11 @@ clean: stop ## Remove all containers
 .PHONY: clean_all
 clean_all: clean stop ## Wipe database link
 	docker-compose down -v
+
+.PHONY: stamp_db
+stamp_db: ## Runs the stamp command to set the base state of the db
+	docker-compose run web alembic --config=./prijateli_tree/migrations/alembic.ini stamp head
+
+.PHONY: create_revision
+create_revision: ## Runs the command that creates the Alembic revision
+	docker-compose run web alembic --config=./prijateli_tree/migrations/alembic.ini revision --autogenerate

--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ The games are a means to provide insights into social learning, the economics of
 To run a data migration, you need to run the following steps:
 1. Before you make any changes to the `database.py` file in the `app` directory, run the following command from your terminal:
 `docker-compose run web alembic --config=./prijateli_tree/migrations/alembic.ini stamp head`
+   - You can also use the command `make stamp`
 2. Make your modifications to the `database.py` file in the `app` directory.
 3. Run the following command from your terminal to produce your migration: `docker-compose run web alembic --config=./prijateli_tree/migrations/alembic.ini revision --autogenerate`
+   - You can also use the command `make create_revision`
 4. You should then see a file added to the `migrations/versions` folder. Modify that as is necessary as Alembic isn't guaranteed to make all the necessary changes.
 5. Run the following command and your migration should be run on the database: `docker-compose run web alembic --config=./prijateli_tree/migrations/alembic.ini upgrade head`
+   - You can also use the command `make upgrade_db`

--- a/prijateli_tree/app/main.py
+++ b/prijateli_tree/app/main.py
@@ -9,7 +9,6 @@ from fastapi.templating import Jinja2Templates
 from fastapi_localization import TranslateJsonResponse
 
 from prijateli_tree.app.config import config
-from prijateli_tree.app.database import Base, engine
 from prijateli_tree.app.routers import administration, games
 from prijateli_tree.app.utils.constants import (
     KEY_ENV,
@@ -19,8 +18,6 @@ from prijateli_tree.app.utils.constants import (
     LANGUAGE_TURKISH,
 )
 
-
-Base.metadata.create_all(bind=engine)
 
 config = config[os.getenv(KEY_ENV)]
 


### PR DESCRIPTION
## Describe Your Changes
Addressed issue where the application would create the tables instead of relying on Alembic.

## Checklist Before Requesting a Review
- [x] The code runs successfully.

```commandline
(prijatelitree-py3.11) michaelp@MacBook-Air-18 PrijateliTree % make clean_all
docker-compose stop
[+] Stopping 2/2
 ✔ Container prijatelitree-web-1       Stopped                                                                                                                                                              0.4s 
 ✔ Container prijatelitree-postgres-1  Stopped                                                                                                                                                              0.1s 
docker-compose rm -f
Going to remove prijatelitree-web-1, prijatelitree-postgres-1
[+] Removing 2/0
 ✔ Container prijatelitree-postgres-1  Removed                                                                                                                                                              0.0s 
 ✔ Container prijatelitree-web-1       Removed                                                                                                                                                              0.0s 
docker-compose down -v
[+] Running 2/0
 ✔ Volume prijatelitree_postgres  Removed                                                                                                                                                                   0.0s 
 ✔ Network prijatelitree_default  Removed                                                                                                                                                                   0.0s 
(prijatelitree-py3.11) michaelp@MacBook-Air-18 PrijateliTree % make
poetry export --without-hashes --format=requirements.txt > requirements.txt
Configuration file exists at /Users/michaelp/Library/Preferences/pypoetry, reusing this directory.

Consider moving TOML configuration files to /Users/michaelp/Library/Application Support/pypoetry, as support for the legacy directory will be removed in an upcoming release.
docker-compose build
[+] Building 1.8s (13/13) FINISHED                                                                                                                                                          docker:desktop-linux
 => [web internal] load .dockerignore                                                                                                                                                                       0.0s
 => => transferring context: 2B                                                                                                                                                                             0.0s
 => [web internal] load build definition from Dockerfile                                                                                                                                                    0.0s
 => => transferring dockerfile: 357B                                                                                                                                                                        0.0s
 => [web internal] load metadata for docker.io/library/python:3.11-slim-buster                                                                                                                              0.7s
 => [web auth] library/python:pull token for registry-1.docker.io                                                                                                                                           0.0s
 => [web 1/7] FROM docker.io/library/python:3.11-slim-buster@sha256:c46b0ae5728c2247b99903098ade3176a58e274d9c7d2efeaaab3e0621a53935                                                                        0.0s
 => [web internal] load build context                                                                                                                                                                       0.2s
 => => transferring context: 1.12MB                                                                                                                                                                         0.2s
 => CACHED [web 2/7] WORKDIR /usr/src/app                                                                                                                                                                   0.0s
 => CACHED [web 3/7] RUN apt-get update   && apt-get -y install netcat gcc postgresql libpq-dev python-dev   && apt-get clean                                                                               0.0s
 => CACHED [web 4/7] RUN pip install --upgrade pip                                                                                                                                                          0.0s
 => CACHED [web 5/7] COPY ./requirements.txt .                                                                                                                                                              0.0s
 => CACHED [web 6/7] RUN pip install -r requirements.txt                                                                                                                                                    0.0s
 => [web 7/7] COPY . .                                                                                                                                                                                      0.5s
 => [web] exporting to image                                                                                                                                                                                0.4s
 => => exporting layers                                                                                                                                                                                     0.4s
 => => writing image sha256:d01b369e114dd2472fec8c2984e79dfb320971cf92f5655cd5dc519b885134aa                                                                                                                0.0s
 => => naming to docker.io/library/prijatelitree-web                                                                                                                                                        0.0s
docker-compose up -d
[+] Building 0.0s (0/0)                                                                                                                                                                     docker:desktop-linux
[+] Running 4/4
 ✔ Network prijatelitree_default       Created                                                                                                                                                              0.0s 
 ✔ Volume "prijatelitree_postgres"     Created                                                                                                                                                              0.0s 
 ✔ Container prijatelitree-postgres-1  Started                                                                                                                                                              0.0s 
 ✔ Container prijatelitree-web-1       Started                                                                                                                                                              0.0s 
Postgres is unavailable - sleeping...
Postgres is up
docker-compose run --rm web alembic --config=./prijateli_tree/migrations/alembic.ini upgrade head
[+] Building 0.0s (0/0)                                                                                                                                                                     docker:desktop-linux
[+] Creating 1/0
 ✔ Container prijatelitree-postgres-1  Running                                                                                                                                                              0.0s 
[+] Building 0.0s (0/0)                                                                                                                                                                     docker:desktop-linux
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade  -> 44f42b35d858, empty message
INFO  [alembic.runtime.migration] Running upgrade 44f42b35d858 -> 47fe187bc716, empty message
INFO  [alembic.runtime.migration] Running upgrade 47fe187bc716 -> e5b498dd07a6, empty message
INFO  [alembic.runtime.migration] Running upgrade e5b498dd07a6 -> 260d503a3c0d, empty message
INFO  [alembic.runtime.migration] Running upgrade 260d503a3c0d -> 8a5c8a351948, empty message
INFO  [alembic.runtime.migration] Running upgrade 8a5c8a351948 -> 5489fb45e45e, empty message
INFO  [alembic.runtime.migration] Running upgrade 5489fb45e45e -> 21c9591d0d5d, empty message
INFO  [alembic.runtime.migration] Running upgrade 21c9591d0d5d -> 30991d313ac8, empty message
INFO  [alembic.runtime.migration] Running upgrade 30991d313ac8 -> 0735fdd31631, empty message
INFO  [alembic.runtime.migration] Running upgrade 0735fdd31631 -> 8d6d2f92cb84, empty message
INFO  [alembic.runtime.migration] Running upgrade 8d6d2f92cb84 -> 3d92f1e628d4, empty message
(prijatelitree-py3.11) michaelp@MacBook-Air-18 PrijateliTree % 
```
