### PR TITLE
Debugging neighbors' positions display in `round.html`

### DIFF
--- a/prijateli_tree/app/utils/games.py
+++ b/prijateli_tree/app/utils/games.py
@@ -209,7 +209,6 @@ def get_previous_answers(
 
         # Check if names are hidden
         if game.game_type.names_hidden:
-            player_id = this_neighbor.user.id
             complete_name = f"Player {this_neighbor.position}: "
         else:
             complete_name = f"{this_neighbor.user.first_name} {this_neighbor.user.last_name}: "

--- a/prijateli_tree/app/utils/games.py
+++ b/prijateli_tree/app/utils/games.py
@@ -210,7 +210,7 @@ def get_previous_answers(
         # Check if names are hidden
         if game.game_type.names_hidden:
             player_id = this_neighbor.user.id
-            complete_name = f"Player {player.position}: "
+            complete_name = f"Player {this_neighbor.position}: "
         else:
             complete_name = f"{this_neighbor.user.first_name} {this_neighbor.user.last_name}: "
 


### PR DESCRIPTION
## Describe Your Changes

- When not displaying the players' names, their positions are now displayed correctly.

Example:

![image](https://github.com/prijatelilab/PrijateliTree/assets/67844597/5eb38eea-5b20-41ca-817e-a26c8aed503a)


## Checklist Before Requesting a Review
- [x] The code runs successfully.

