### PR TITLE
Add connection to post-survey (#105)

### DIFF
--- a/prijateli_tree/app/routers/games.py
+++ b/prijateli_tree/app/routers/games.py
@@ -18,7 +18,9 @@ from prijateli_tree.app.database import (
 )
 from prijateli_tree.app.utils.constants import (
     DENIR_FACTOR,
+    END_SURVEY_LINK,
     FILE_MODE_READ,
+    RULE_SURVEY_LINK,
     STANDARD_ENCODING,
     WINNING_SCORE,
 )
@@ -294,10 +296,29 @@ def get_qualtrics(
     request: Request,
     player_id: int,
     game_id: int,
+    db: Session = Depends(get_db),
 ) -> Response:
+    _, player = get_game_and_player(game_id, player_id, db)
+
+    if player.completed_game:
+        survey_link = RULE_SURVEY_LINK
+    else:
+        survey_link = END_SURVEY_LINK
+
+    lang = player.language.abbr.upper()
+    if lang == "SQ":
+        lang = "SQI"
+
+    survey_link = survey_link + "?Q_Language=" + lang
+    print(survey_link)
     return templates.TemplateResponse(
         "qualtrics.html",
-        {"request": request, "player_id": player_id, "game_id": game_id},
+        {
+            "request": request,
+            "player_id": player_id,
+            "game_id": game_id,
+            "survey_link": survey_link,
+        },
     )
 
 

--- a/prijateli_tree/app/templates/qualtrics.html
+++ b/prijateli_tree/app/templates/qualtrics.html
@@ -4,9 +4,11 @@
   window.addEventListener("message", receiveMessage, false);
 
   function receiveMessage(event) {
-    if(event.data.includes("End of Survey")){
+    if(event.data.includes("End of Pre-Survey")){
         console.log("We're getting information across iframe")
         window.location.href = "/games/{{game_id}}/player/{{player_id}}/round"
+    } else if (event.data.includes("End of Post-Survey")) {
+      window.location.href = "/games/{{game_id}}/player/{{player_id}}/end_of_session"
     }
   }
   </script>
@@ -16,10 +18,6 @@
 {% endblock title %}
 {% block content %}
   <div class="container-sm general-container">
-    <iframe src="https://uchicago.co1.qualtrics.com/jfe/form/SV_eaqREcRYZgwsuHk"
-            title="Pre-survey"
-            frameborder="0"
-            height="1200px"
-            width="1000px"></iframe>    </iframe>
+    <iframe src={{ survey_link }} title="Survey" frameborder="0" height="1200px" width="1000px"></iframe>    </iframe>
   </div>
 {% endblock content %}

--- a/prijateli_tree/app/templates/round.html
+++ b/prijateli_tree/app/templates/round.html
@@ -6,6 +6,7 @@
   {% include "student_info.html" %}
   <div class="container-sm general-container">
     {% if first_round %}
+      {{ text.game_first_round.the_computer_chose }}
       <h2>
         Your Ball:
         {% if ball == 'R' %}

--- a/prijateli_tree/app/utils/constants.py
+++ b/prijateli_tree/app/utils/constants.py
@@ -34,3 +34,11 @@ LANGUAGE_TURKISH = "tr"
 # Point Constants
 WINNING_SCORE = 100
 DENIR_FACTOR = 0.25
+
+# Survey Links
+RULE_SURVEY_LINK = (
+    "https://uchicago.co1.qualtrics.com/jfe/form/SV_eaqREcRYZgwsuHk"
+)
+END_SURVEY_LINK = (
+    "https://uchicago.co1.qualtrics.com/jfe/form/SV_bwNRzTxU1cU5m7Q"
+)

--- a/prijateli_tree/app/utils/constants.py
+++ b/prijateli_tree/app/utils/constants.py
@@ -36,9 +36,9 @@ WINNING_SCORE = 100
 DENIR_FACTOR = 0.25
 
 # Survey Links
-RULE_SURVEY_LINK = (
+PRE_SURVEY_LINK = (
     "https://uchicago.co1.qualtrics.com/jfe/form/SV_eaqREcRYZgwsuHk"
 )
-END_SURVEY_LINK = (
+POST_SURVEY_LINK = (
     "https://uchicago.co1.qualtrics.com/jfe/form/SV_bwNRzTxU1cU5m7Q"
 )


### PR DESCRIPTION
<!--- Please write your PR name in the present imperative tense. Examples of that tense are: "Fix issue in the dispatcher where…", "Improve our handling of…", etc." -->
<!-- For more information on Pull Requests, you can reference here: https://success.vanillaforums.com/kb/articles/228-using-pull-requests-to-contribute -->
## Describe Your Changes

- Extend get_qualtrics and related template to return pre- or post-survey depending on timing of when we hit the route. 
- make survey URLs constants

## Non-Obvious Technical Information

In qualtrics, we add js to send an "End of Survey" message and create an embedded data field to capture the cid when we pass it. 

## Checklist Before Requesting a Review
- [x] The code runs successfully.

```commandline
2023-12-20 00:13:22 INFO:     172.25.0.1:36974 - "GET /games/9/player/53/end_of_game HTTP/1.1" 200 OK
2023-12-20 00:13:23 INFO:     172.25.0.1:36974 - "GET /games/9/player/53/next_game HTTP/1.1" 303 See Other
2023-12-20 00:13:23 INFO:     172.25.0.1:36974 - "GET /games/9/player/53/survey HTTP/1.1" 200 OK
```
Result of call after a complete game

![Screenshot 2023-12-20 at 12 13 33 AM](https://github.com/prijatelilab/PrijateliTree/assets/25271399/cca53e66-7f10-4d3f-b6fa-089186630d09)

Result of call at start of session -- notice we get the MK survey. We don't have translations in SQ, TR so cannot test those now.

![Screenshot 2023-12-19 at 11 42 09 PM](https://github.com/prijatelilab/PrijateliTree/assets/25271399/2417b108-4b7c-493f-a1c4-29e562372d40)

