### PR TITLE
Add practice language to start of game screen

### DIFF
--- a/prijateli_tree/app/templates/end_of_game.html
+++ b/prijateli_tree/app/templates/end_of_game.html
@@ -3,7 +3,7 @@
   End of Game
 {% endblock title %}
 {% block content %}
-  {% include "student_info.html" %}
+  {% include "score_header.html" %}
   <div class="container-sm general-container">
     <div class="pb-4">
       <h1>

--- a/prijateli_tree/app/templates/qualtrics.html
+++ b/prijateli_tree/app/templates/qualtrics.html
@@ -6,7 +6,7 @@
   function receiveMessage(event) {
     if(event.data.includes("End of Pre-Survey")){
         console.log("We're getting information across iframe")
-        window.location.href = "/games/{{game_id}}/player/{{player_id}}/round"
+        window.location.href = "/games/{{game_id}}/player/{{player_id}}/start_of_game"
     } else if (event.data.includes("End of Post-Survey")) {
       window.location.href = "/games/{{game_id}}/player/{{player_id}}/end_of_session"
     }

--- a/prijateli_tree/app/templates/real_game_transition.html
+++ b/prijateli_tree/app/templates/real_game_transition.html
@@ -3,7 +3,7 @@
   Real Game Transition
 {% endblock title %}
 {% block content %}
-  {% include "student_info.html" %}
+  {% include "score_header.html" %}
   <div class="container-sm general-container">
     <div class="pb-4">
       <h2>{{ text.real_game_intro.now_we_practiced }}</h2>

--- a/prijateli_tree/app/templates/round.html
+++ b/prijateli_tree/app/templates/round.html
@@ -3,7 +3,7 @@
   PrijateliTree - View Round
 {% endblock title %}
 {% block content %}
-  {% include "student_info.html" %}
+  {% include "score_header.html" %}
   <div class="container-sm general-container">
     {% if first_round %}
       {{ text.game_first_round.the_computer_chose }}

--- a/prijateli_tree/app/templates/score_header.html
+++ b/prijateli_tree/app/templates/score_header.html
@@ -1,0 +1,18 @@
+<div class="container-sm general-container">
+  <div class="row">
+    <div class="col text-start">
+      {% if not completed_game %}
+        <p style="margin-bottom: 5px;">{{ text.game_first_round.round }}: {{ round_progress }}</p>
+      {% endif %}
+      {% if practice_game %}
+        <p style="margin-bottom: 5px;">{{ text.game_video.game }}: {{ practice_game_progress }}</p>
+      {% else %}
+        <p style="margin-bottom: 5px;">Real Game: {{ real_game_progress }}</p>
+      {% endif %}
+    </div>
+    <div class="col text-end">
+      <p style="margin-bottom: 5px;">{{ player_name }}</p>
+      <p style="margin-bottom: 5px;">{{ text.game_video.score }}: {{ player_score }}</p>
+    </div>
+  </div>
+</div>

--- a/prijateli_tree/app/templates/start_of_game.html
+++ b/prijateli_tree/app/templates/start_of_game.html
@@ -5,13 +5,21 @@
 {% block content %}
   <div class="container-sm general-container">
     <div class="pb-4">
-      <h1>{{ text.ready_to_play.get_ready }}</h1>
-    </div>
+      <h1> 
     {% if practice_game %}
-      <h3>{{ text.intro_practice.since_these_rules }}</h3>
+     {{ text.intro_practice.now_you_will_play }}
     {% else %}
-      <h3>{{ text.real_game_intro.added_points | replace('{X}', points) }}</h3>
+      {{ text.ready_to_play.get_ready }}
     {% endif %}
+    </h1>
+    </div>
+    <h3>
+    {% if practice_game %}
+     {{ text.intro_practice.since_these_rules }}
+    {% else %}
+      {{ text.real_game_intro.added_points | replace('{X}', points) }}
+    {% endif %}
+  </h3>
     <div class="p-5">
       <form method="get"
             action="{{ url_for('view_round', player_id=player_id, game_id=game_id) }}">

--- a/prijateli_tree/app/templates/start_of_game.html
+++ b/prijateli_tree/app/templates/start_of_game.html
@@ -3,7 +3,7 @@
   Start of Game
 {% endblock title %}
 {% block content %}
-  <div class="container-sm general-container">
+  <div class="container-sm general-container col-md-8 offset-md-2">
     <div class="pb-4">
     <h1> 
     {% if practice_game %}

--- a/prijateli_tree/app/templates/start_of_game.html
+++ b/prijateli_tree/app/templates/start_of_game.html
@@ -5,21 +5,21 @@
 {% block content %}
   <div class="container-sm general-container col-md-8 offset-md-2">
     <div class="pb-4">
-    <h1> 
-    {% if practice_game %}
-     {{ text.intro_practice.now_you_will_play }}
-    {% else %}
-      {{ text.ready_to_play.get_ready }}
-    {% endif %}
-    </h1>
+      <h1>
+        {% if practice_game %}
+          {{ text.intro_practice.now_you_will_play }}
+        {% else %}
+          {{ text.ready_to_play.get_ready }}
+        {% endif %}
+      </h1>
     </div>
     <h3>
-    {% if practice_game %}
-     {{ text.intro_practice.since_these_rules }}
-    {% else %}
-      {{ text.real_game_intro.added_points | replace('{X}', points) }}
-    {% endif %}
-  </h3>
+      {% if practice_game %}
+        {{ text.intro_practice.since_these_rules }}
+      {% else %}
+        {{ text.real_game_intro.added_points | replace('{X}', points) }}
+      {% endif %}
+    </h3>
     <div class="p-5">
       <form method="get"
             action="{{ url_for('view_round', player_id=player_id, game_id=game_id) }}">

--- a/prijateli_tree/app/templates/start_of_game.html
+++ b/prijateli_tree/app/templates/start_of_game.html
@@ -5,7 +5,7 @@
 {% block content %}
   <div class="container-sm general-container">
     <div class="pb-4">
-      <h1> 
+    <h1> 
     {% if practice_game %}
      {{ text.intro_practice.now_you_will_play }}
     {% else %}

--- a/prijateli_tree/app/templates/waiting.html
+++ b/prijateli_tree/app/templates/waiting.html
@@ -37,7 +37,7 @@
   PrijateliTree - Waiting
 {% endblock title %}
 {% block content %}
-  {% include "student_info.html" %}
+  {% include "score_header.html" %}
   <div class="container-sm general-container">
     <h1>{{ text.waiting_screen.waiting }}</h1>
     <br>


### PR DESCRIPTION
<!--- Please write your PR name in the present imperative tense. Examples of that tense are: "Fix issue in the dispatcher where…", "Improve our handling of…", etc." -->
<!-- For more information on Pull Requests, you can reference here: https://success.vanillaforums.com/kb/articles/228-using-pull-requests-to-contribute -->
## Describe Your Changes

- Added practice language to start of game screen and updated redirect from survey template to start of game.
- renamed score_header.html 

## Non-Obvious Technical Information


## Checklist Before Requesting a Review
- [X] The code runs successfully.

```commandline
2023-12-23 13:11:52 INFO:     172.25.0.1:59384 - "GET /games/18/player/103/survey HTTP/1.1" 200 OK
2023-12-23 13:11:59 INFO:     172.25.0.1:47922 - "GET /games/18/player/103/start_of_game HTTP/1.1"
```
Start of game from practice rounds
<img width="1509" alt="Screenshot 2023-12-23 at 12 34 24 PM" src="https://github.com/prijatelilab/PrijateliTree/assets/25271399/2855705f-3580-4874-b514-2091793c1d68">

Start of game from official rounds
<img width="1505" alt="Screenshot 2023-12-23 at 12 34 38 PM" src="https://github.com/prijatelilab/PrijateliTree/assets/25271399/810116ad-2d34-4d03-baf4-6166a1173284">

