### PR TITLE
Remove extra \ from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ and other human behaviors.
 - Python 🐍 version >= v`3.11`
 - Poetry package manager. If you need information on how to download poetry, check [here](https://python-poetry.org/docs/#installation).
 - PostgreSQL v14.
-  - For accessing the database your configuration should look roughly like this:\
+  - For accessing the database your configuration should look roughly like this: 
   <img src="misc/DBConfig.png" alt="Database Access Configuration" width="400px">
 
 ## Steps for Running the Application

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ and other human behaviors.
 - Python 🐍 version >= v`3.11`
 - Poetry package manager. If you need information on how to download poetry, check [here](https://python-poetry.org/docs/#installation).
 - PostgreSQL v14.
-  - For accessing the database your configuration should look roughly like this: 
+  - For accessing the database your configuration should look roughly like this:
   <img src="misc/DBConfig.png" alt="Database Access Configuration" width="400px">
 
 ## Steps for Running the Application


### PR DESCRIPTION
## Describe Your Changes
What I thought was a line break in markup, was sadly not. Womp womp.


<img width="811" alt="Screenshot 2024-01-06 at 2 54 25 PM" src="https://github.com/prijatelilab/PrijateliTree/assets/5885605/a9aa28b5-38be-4736-91c9-1378b40f5976">