### PR TITLE
add api for qualtrics facilitators

### DIFF
--- a/prijateli_tree/app/routers/games.py
+++ b/prijateli_tree/app/routers/games.py
@@ -10,6 +10,7 @@ from fastapi import APIRouter, Depends, Form, HTTPException, Request, Response
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
+from sqlalchemy import desc
 
 from prijateli_tree.app.database import (
     Game,
@@ -81,8 +82,9 @@ def choose_session_players(
 ) -> Response:
     session = (
         db.query(GameSession)
-        .filter_by(session_key=session_key.lower())
-        .one_or_none()
+        .filter_by(session_key=session_key.lower()) 
+        .order_by(desc('created_at'))
+        .first()
     )
     if session is None:
         return templates.TemplateResponse(

--- a/prijateli_tree/app/routers/games.py
+++ b/prijateli_tree/app/routers/games.py
@@ -9,8 +9,8 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, Form, HTTPException, Request, Response
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
-from sqlalchemy.orm import Session
 from sqlalchemy import desc
+from sqlalchemy.orm import Session
 
 from prijateli_tree.app.database import (
     Game,
@@ -82,8 +82,8 @@ def choose_session_players(
 ) -> Response:
     session = (
         db.query(GameSession)
-        .filter_by(session_key=session_key.lower()) 
-        .order_by(desc('created_at'))
+        .filter_by(session_key=session_key.lower())
+        .order_by(desc("created_at"))
         .first()
     )
     if session is None:

--- a/prijateli_tree/app/templates/administration/create_session.html
+++ b/prijateli_tree/app/templates/administration/create_session.html
@@ -41,7 +41,7 @@
         formData.append("player_" + numbers[i], parseInt(selectedRows[i][0]))
         lang = selectedRows[i][1]
         languageCounter[lang] = languageCounter[lang] ? languageCounter[lang]  + 1 : 1;
-        groups = selectedRows[i][2].split('\n').map(s => s.trim());
+        groups = selectedRows[i][2].split('&nbsp;').map(s => s.trim());
         for (const g of groups) {
           if (g) { // g can be ""
             groupCounter[g] = groupCounter[g] ? groupCounter[g]  + 1 : 1;


### PR DESCRIPTION
<!--- Please write your PR name in the present imperative tense. Examples of that tense are: "Fix issue in the dispatcher where…", "Improve our handling of…", etc." -->
<!-- For more information on Pull Requests, you can reference here: https://success.vanillaforums.com/kb/articles/228-using-pull-requests-to-contribute -->
## Describe Your Changes

Adds a route that can be called in qualtrics to get session players names

## Non-Obvious Technical Information


## Checklist Before Requesting a Review
- [x] The code runs successfully.

```commandline
2024-03-13 22:04:17 INFO:     172.21.0.1:45700 - "GET /games/get_session_players/w43ma HTTP/1.1" 200 OK
```
